### PR TITLE
fixed function 'cleanup'

### DIFF
--- a/bin/trash
+++ b/bin/trash
@@ -229,7 +229,8 @@ _sf_check_args () { # {{{
 cleanup () { # Clean up the trash box {{{
   # Cleanup fully
   if [ "$1" -eq 1 ];then
-    rm -rf "$mytbox/*"
+    rm -rf "${mytbox}"/*
+    rm -rf "${mytbox}"/.* 2>/dev/null
     echo -n > "$_s_file"
     return 0
   fi


### PR DESCRIPTION
`-C` オプション付加時の`$mytbox`以下全削除の処理が正しく機能していなかったようなので修正しました。

私の環境のだと `rm -rf "${mytbox}"/.*` で
```
rm: cannot remove directory: `.'`
rm: cannot remove directory: `..'
```
のエラーがでるので、エラー出力を捨ててます。
`$mytbox`を中身ごと削除して作り直した方がいいかもしれないです。
